### PR TITLE
Update package.json to be x64 compatible

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,5 @@
     "windows-eventlog" : "0.1.3"
   },
   "main": "./lib/eventlog",
-  "os" : [ "win32"],
-  "cpu": [ "ia32" ]
+  "os" : [ "win32"]
 }


### PR DESCRIPTION
Although 0.1.3 was x64 compatible, the package.json still limited it to ia32 machines.
